### PR TITLE
Fix typo in compiled-languages.md

### DIFF
--- a/troubleshooting/codeql-builds/compiled-languages.md
+++ b/troubleshooting/codeql-builds/compiled-languages.md
@@ -64,5 +64,5 @@ Helpful Articles to understand how to review, troubleshoot, and debug logs:
 - [Adding artifacts on every CodeQL Run](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow#creating-codeql-debugging-artifacts-using-a-workflow-flag)
 - [Exit Codes](https://codeql.github.com/docs/codeql-cli/exit-codes/)
 
-## Optimizaitons
+## Optimizations
 - CodeQL Docs -  [The build takes too long](https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow)


### PR DESCRIPTION
Fixed typo in troubleshooting/codeql-builds/compiled-languages.md.

It stuck out like a sore thumb so I had to fix it...