### PR TITLE
Add link to new SARIF troubleshooting articles in user docs

### DIFF
--- a/troubleshooting/sarif-upload/troubleshooting.md
+++ b/troubleshooting/sarif-upload/troubleshooting.md
@@ -1,4 +1,7 @@
 ## SARIF Upload Errors
+
+For the latest information about troubleshooting SARIF errors, see "[Troubleshooting SARIF uploads](https://docs.github.com/en/code-security/code-scanning/troubleshooting-sarif-uploads)." If anything is missing, or you can see anything that can be improved, open an issue in [`docs-content`](https://github.com/github/docs-content/issues/new?template=improve-existing-docs.yml) with the details.
+
 * Test environment - GHES 3.2.1 + CodeQL CLI 2.7.2
 
 :gift: wrong ref:


### PR DESCRIPTION
👋🏻 A while back, @KittyChui opened an issue asking the docs team to add information to the user docs about how to fix SARIF upload errors: https://github.com/github/docs-content/issues/10034.

We created the articles but forgot to close the loop and update this article to link to the new docs.