### PR TITLE
3rd party list - Scala / Rust

### DIFF
--- a/code-scanning-guides/integrations/code-scanning-third-party-integrations.md
+++ b/code-scanning-guides/integrations/code-scanning-third-party-integrations.md
@@ -516,6 +516,8 @@ changes and not directly in this file.
   - [Open Source Tool Aggregator](https://docs.codacy.com/getting-started/supported-languages-and-tools/)
 - [Coverity](https://www.synopsys.com/software-integrity/security-testing/static-analysis-sast.html) by Synopsys
   - Commercial Requirement for Private Repositories
+- [Semgrep](https://semgrep.dev/)
+  - Commercial Requirement for Private Repositories
 - [SpotBugs with FindSecBugs](https://github.com/marketplace/actions/spotbugs-with-findsecbugs)
 - [Veracode](https://veracode.com/)
   - Commercial Requirement for Private Repositories

--- a/code-scanning-guides/integrations/code-scanning-third-party-integrations.md
+++ b/code-scanning-guides/integrations/code-scanning-third-party-integrations.md
@@ -496,8 +496,10 @@ changes and not directly in this file.
   - Commercial Requirement for Private Repositories
 
 ### Rust
-
+- [Clippy](https://github.com/rust-lang/rust-clippy) + [Clippy SARIF](https://github.com/psastras/sarif-rs/tree/main/clippy-sarif#example-1)
 - [DevSkim](https://github.com/microsoft/DevSkim) by Microsoft
+- [Semgrep](https://semgrep.dev/)
+  - Commercial Requirement for Private Repositories
 
 ### SQL
 


### PR DESCRIPTION
This pull request includes a minor update to the `code-scanning-guides/integrations/code-scanning-third-party-integrations.md` file. The change adds `Semgrep` to the list of third-party integrations for code scanning, with a note that it requires a commercial license for private repositories.