### PR TITLE
fix: add batch processing to prevent token exhaustion in codeql-version-tracker

### DIFF
--- a/.github/workflows/codeql-version-tracker.lock.yml
+++ b/.github/workflows/codeql-version-tracker.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1e8288040eb04d7b73636ae2af559ab6eca36f38cbb2047fae8e373ec1a3fa14","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ea6a9a853cf4149aef5eb15e8545d812fae241c8dbb3248128d461223e8c78ef","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -167,20 +167,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_fa2f94184d2d4fac_EOF'
+          cat << 'GH_AW_PROMPT_7df1239e81ee14d9_EOF'
           <system>
-          GH_AW_PROMPT_fa2f94184d2d4fac_EOF
+          GH_AW_PROMPT_7df1239e81ee14d9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_fa2f94184d2d4fac_EOF'
+          cat << 'GH_AW_PROMPT_7df1239e81ee14d9_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_fa2f94184d2d4fac_EOF
+          GH_AW_PROMPT_7df1239e81ee14d9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_fa2f94184d2d4fac_EOF'
+          cat << 'GH_AW_PROMPT_7df1239e81ee14d9_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -210,12 +210,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_fa2f94184d2d4fac_EOF
+          GH_AW_PROMPT_7df1239e81ee14d9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_fa2f94184d2d4fac_EOF'
+          cat << 'GH_AW_PROMPT_7df1239e81ee14d9_EOF'
           </system>
           {{#runtime-import .github/workflows/codeql-version-tracker.md}}
-          GH_AW_PROMPT_fa2f94184d2d4fac_EOF
+          GH_AW_PROMPT_7df1239e81ee14d9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -408,9 +408,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_258210693eeb292c_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_64e99294c9006f12_EOF'
           {"create_pull_request":{"max":1,"max_patch_size":1024,"preserve_branch_name":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_258210693eeb292c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_64e99294c9006f12_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -608,7 +608,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_126f233a945f152b_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_14bd53bfecefa2a2_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -649,7 +649,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_126f233a945f152b_EOF
+          GH_AW_MCP_CONFIG_14bd53bfecefa2a2_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -661,7 +661,7 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 45
+        timeout-minutes: 60
         run: |
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
@@ -977,7 +977,7 @@ jobs:
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
-          GH_AW_TIMEOUT_MINUTES: "45"
+          GH_AW_TIMEOUT_MINUTES: "60"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/codeql-version-tracker.md
+++ b/.github/workflows/codeql-version-tracker.md
@@ -7,7 +7,7 @@ permissions:
   contents: read
   pull-requests: read
   issues: read
-timeout-minutes: 45
+timeout-minutes: 60
 tools:
   github:
     toolsets: [default]
@@ -59,33 +59,40 @@ Check cache-memory for a file named `codeql-version-tracker-state.json`. If it e
 - `last_checked`: Timestamp of the last run (use filesystem-safe format `YYYY-MM-DD-HH-MM-SS`)
 - `processed_releases`: Array of CodeQL bundle version strings already processed (e.g., `["2.25.2", "2.25.1", "2.25.0"]`)
 
-If the file does not exist, this is the first run — you will need to process ALL historical releases.
+If the file does not exist, this is the first run. See the batch processing rules below for first-run behavior.
 
 ### Step 2: Discover CodeQL Bundle Releases
 
 Use GitHub tools to list releases from `github/codeql-action`. Filter to releases where the tag name starts with `codeql-bundle-v`. These are the bundle releases.
 
-Paginate through ALL releases (there are many pages). Collect every `codeql-bundle-v*` tagged release.
+> **Important — Do NOT paginate through all releases at once.** The `github/codeql-action` repository has hundreds of releases. Fetching all of them in a single run will exhaust your token budget. Instead, use the batch processing approach below.
 
-Compare against the `processed_releases` list from cache. Identify which releases are **new** (not yet processed).
+List releases page by page (newest first). On each page, collect `codeql-bundle-v*` tagged releases and check them against `processed_releases` from cache. **Stop paginating** once you have collected enough unprocessed releases to fill the batch (see limits below), or once you reach releases that are already processed.
 
-If there are no new releases, skip to Step 5 (save state) and exit without creating a PR.
+Compare against the `processed_releases` list from cache. Identify which releases are **unprocessed** (not yet in the list).
+
+#### Batch Processing Limits
+
+- **First run** (no cache state): Process only the **10 most recent** CodeQL bundle releases. Do not attempt to process the entire history — older releases will be backfilled in subsequent runs.
+- **Subsequent runs**: Process up to **5 new releases** (releases newer than any in `processed_releases`) **plus** up to **5 backfill releases** (older releases not yet in `processed_releases`) per run, for a maximum of **10 releases per run**.
+- **Backfill strategy**: After processing new releases, continue paginating backwards from the oldest release in `processed_releases` to find up to 5 more unprocessed historical releases. This ensures the tracker progressively fills in older versions over multiple scheduled runs.
+- **When more remain**: If there are still unprocessed releases after hitting the batch limit, save your progress to cache-memory (Step 5) and call `noop` with a message like: "Processed N releases this run. M older releases remain for backfill in future runs." Do NOT create a PR with partial data if you haven't finished the current batch — only create a PR if you successfully processed all releases in this batch.
+
+If there are no new or backfill releases to process, skip to Step 5 (save state) and exit without creating a PR.
 
 ### Step 3: Extract Pack Versions for Each New Release
 
 For each new CodeQL bundle release (e.g., `codeql-bundle-v2.25.2`):
 
 1. Extract the version number from the tag (e.g., `2.25.2`)
-2. The corresponding tag in the `github/codeql` repository is `codeql-cli/v<VERSION>` (e.g., `codeql-cli/v2.25.2`)
-3. For each language listed above, read the `qlpack.yml` file from `github/codeql` at that tag:
+2. **Optimization — Check the bundle release body first.** Each `codeql-bundle-v*` release body on `github/codeql-action` lists all included packs with links to their source and changelogs. While the release body does not contain version numbers directly, it confirms which languages are included in that bundle (helping you skip 404s for unsupported languages).
+3. The corresponding tag in the `github/codeql` repository is `codeql-cli/v<VERSION>` (e.g., `codeql-cli/v2.25.2`)
+4. For each language listed above, read the `qlpack.yml` file from `github/codeql` at that tag:
    - **Queries pack**: `<language>/ql/src/qlpack.yml` — extract the `version:` field
    - **Library pack**: `<language>/ql/lib/qlpack.yml` — extract the `version:` field
-4. If the file doesn't exist at that tag (404), the language was not yet supported — record as "N/A"
+5. If the file doesn't exist at that tag (404), the language was not yet supported — record as "N/A"
 
-> **Rate Limiting**: There are many releases and many languages. To avoid hitting API rate limits:
-> - Process releases in batches
-> - If you encounter rate limit errors, pause and note which releases still need processing
-> - Prioritize newer releases first (process in reverse chronological order)
+> **Rate Limiting**: With batch limits in place, each run processes at most 10 releases × 20 files = 200 file reads, which is well within API limits. If you still encounter rate limit errors, save progress to cache and call `noop`.
 
 ### Step 4: Update the Tracking Page
 
@@ -131,6 +138,8 @@ When updating, merge new release rows into the existing tables. Keep existing da
 Write the updated state to cache-memory as `codeql-version-tracker-state.json`:
 - `last_checked`: Current timestamp in `YYYY-MM-DD-HH-MM-SS` format (no colons, no T, no Z)
 - `processed_releases`: Full list of all processed release versions (merge new with existing)
+- `oldest_processed`: The oldest CodeQL version string that has been processed (e.g., `"2.20.0"`). This helps the backfill step know where to resume paginating from.
+- `backfill_complete`: Boolean. Set to `true` once a run finds no more unprocessed releases older than `oldest_processed`. This tells future runs to skip backfill pagination entirely.
 
 Always save state, even if no new releases were found.
 


### PR DESCRIPTION
## Problem

The first run of the CodeQL Version Tracker agentic workflow ([run #24745165758](https://github.com/advanced-security/advanced-security-material/actions/runs/24745165758)) exhausted **12.3M effective tokens** over 39 minutes trying to paginate through ALL `github/codeql-action` releases and fetch `qlpack.yml` files for every historical bundle version (10 languages × 2 packs × hundreds of releases = thousands of API calls).

The agent never reached the PR creation step, resulting in [issue #77](https://github.com/advanced-security/advanced-security-material/issues/77): *"Agent succeeded but produced no safe outputs."*

## Root Cause

The workflow prompt instructed the agent to *"Paginate through ALL releases"* on every run, including the first run with no cache state. This is an unbounded task that exceeds the agent's token/context budget.

## Changes

### 1. First-run scope limit
- First run now processes only the **10 most recent** CodeQL bundle releases instead of the entire history.

### 2. Batch processing with explicit backfill
- Subsequent runs process up to **5 new + 5 backfill releases** (max 10/run).
- **Backfill strategy**: After processing new releases, the agent paginates backwards from the oldest processed release to progressively fill in older versions. This means the full history is built up over multiple weekly runs automatically.
- Added `oldest_processed` and `backfill_complete` fields to the cache state schema so the agent knows where to resume backfill and when it's done.

### 3. Release body pre-check optimization
- The agent now checks the bundle release body first to identify which languages are included, reducing unnecessary 404 requests for unsupported languages in older versions.

### 4. Timeout increase
- Increased from 45 to 60 minutes to give the agent more headroom.

## Backfill Behavior

| Run | What gets processed |
|-----|-------------------|
| 1st (no cache) | 10 most recent bundle releases |
| 2nd | Up to 5 new + 5 older (backfill) |
| 3rd+ | Same pattern, progressively filling history |
| Eventually | `backfill_complete: true` — only new releases processed |

Fixes #77