### PR TITLE
fix: validate cache against output file to prevent stale cache no-ops

### DIFF
--- a/.github/workflows/codeql-version-tracker.md
+++ b/.github/workflows/codeql-version-tracker.md
@@ -61,6 +61,12 @@ Check cache-memory for a file named `codeql-version-tracker-state.json`. If it e
 
 If the file does not exist, this is the first run. See the batch processing rules below for first-run behavior.
 
+#### Cache Validation
+
+After loading the cache, **verify that the output file `codeql/codeql-version-tracker.md` actually exists** in this repository. If the cache claims releases are processed but the tracking file does not exist, the cache is stale from a previous failed run that saved progress but never created the output. In this case:
+- **Reset the cache**: Treat all releases as unprocessed (same as first run behavior).
+- Log a message: "Cache state found but output file missing — resetting to first-run mode."
+
 ### Step 2: Discover CodeQL Bundle Releases
 
 Use GitHub tools to list releases from `github/codeql-action`. Filter to releases where the tag name starts with `codeql-bundle-v`. These are the bundle releases.


### PR DESCRIPTION
## Problem

[Run #24792832302](https://github.com/advanced-security/advanced-security-material/actions/runs/24792832302) reported a no-op: *"All 74 releases from 2.13.4 to 2.25.2 are already processed."*

But `codeql/codeql-version-tracker.md` **does not exist** in the repo, and no PR was ever created. The tracker file was never generated.

## Root Cause: Poisoned Cache

| Run | What happened |
|-----|-------------|
| Run 1 (#24745165758) | Agent spent 39 min processing releases, saved 74 releases to cache-memory as "processed", but exhausted tokens before creating the output file or PR (Steps 4-6 never ran) |
| Run 2 (#24792832302) | Loaded stale cache → saw all 74 releases as "processed" → no new releases found → called `noop` ❌ |

The cache-memory persists across runs. Run 1 saved partial progress (release list) but never produced the deliverable. Run 2 trusted the cache blindly.

## Fix

Added a **cache validation step** to Step 1: after loading cache state, the agent verifies that `codeql/codeql-version-tracker.md` actually exists in the repository. If the cache says releases are processed but the output file is missing, the cache is reset and the agent starts fresh (first-run behavior).

This prevents stale cache from a failed/partial run from causing future runs to incorrectly no-op.

Fixes #80